### PR TITLE
Fix Weis URL

### DIFF
--- a/crawlers/weis.js
+++ b/crawlers/weis.js
@@ -5,7 +5,7 @@ const renderStaticSlackMessage = require('../utils/renderStaticSlackMessage');
 
 dotenv.config();
 
-const dataURL = 'https://c.ateb.com/3f647956b456425d9c12360db8e4fdb4/';
+const dataURL = 'https://c.ateb.com/8d8feb6dce7d4d598f753362d06d1e64/';
 const scheduleURL = dataURL;
 const name = 'Weis'
 const url = process.env.SLACK_WEBHOOK_URL;


### PR DESCRIPTION
It looks like Weis has 2 URLs, one for NY and one for PA. It was using the NY url; this should now be the PA URL.